### PR TITLE
Allow the user to specify a comma separated list of registers to read.

### DIFF
--- a/gdb-svd.py
+++ b/gdb-svd.py
@@ -269,7 +269,7 @@ class GdbSvdCmd(gdb.Command):
 
 # sub commands
 class GdbSvdGetCmd(GdbSvdCmd):
-    """Get register(s) value(s): svd get [peripheral] [register]
+    """Get register(s) value(s): svd get [peripheral] [register1[,register2,...]]
     """
     def __init__(self, device, peripherals):
         GdbSvdCmd.__init__(self, device, peripherals)
@@ -301,8 +301,8 @@ class GdbSvdGetCmd(GdbSvdCmd):
             regs = periph.get_registers()
 
             if len(args) == 2:
-                reg_name = args[1].upper()
-                regs = [[r for r in regs if r.name == reg_name][0]]
+                reg_names = [r.upper() for r in args[1].split(',')]
+                regs = [r for r in regs if r.name in reg_names]
 
             GdbSvdCmd.print_registers(self, periph, regs)
 


### PR DESCRIPTION
Allows you to specify multiple registers, eg
```
(gdb) svd get LPUART1 ISR,CR1,CR2,CR3
+LPUART1------------+------------+------------------------------------------------------------------------------------------------------+
| name | address    | value      | fields                                                                                               |
+------+------------+------------+------------------------------------------------------------------------------------------------------+
| CR1  | 0x40004800 | 0x00000000 | M1[28:28]=0x0 DEAT4[25:25]=0x0 DEAT3[24:24]=0x0 DEAT2[23:23]=0x0 DEAT1[22:22]=0x0 DEAT0[21:21]=0x0   |
|      |            |            | DEDT4[20:20]=0x0 DEDT3[19:19]=0x0 DEDT2[18:18]=0x0 DEDT1[17:17]=0x0 DEDT0[16:16]=0x0 CMIE[14:14]=0x0 |
|      |            |            | MME[13:13]=0x0 M0[12:12]=0x0 WAKE[11:11]=0x0 PCE[10:10]=0x0 PS[9:9]=0x0 PEIE[8:8]=0x0 TXEIE[7:7]=0x0 |
|      |            |            | TCIE[6:6]=0x0 RXNEIE[5:5]=0x0 IDLEIE[4:4]=0x0 TE[3:3]=0x0 RE[2:2]=0x0 UESM[1:1]=0x0 UE[0:0]=0x0      |
| CR2  | 0x40004804 | 0x00000000 | ADD4_7[31:28]=0x0 ADD0_3[27:24]=0x0 MSBFIRST[19:19]=0x0 TAINV[18:18]=0x0 TXINV[17:17]=0x0            |
|      |            |            | RXINV[16:16]=0x0 SWAP[15:15]=0x0 STOP[13:12]=0x0 CLKEN[11:11]=0x0 ADDM7[4:4]=0x0                     |
| CR3  | 0x40004808 | 0x00000000 | WUFIE[22:22]=0x0 WUS[21:20]=0x0 DEP[15:15]=0x0 DEM[14:14]=0x0 DDRE[13:13]=0x0 OVRDIS[12:12]=0x0      |
|      |            |            | CTSIE[10:10]=0x0 CTSE[9:9]=0x0 RTSE[8:8]=0x0 DMAT[7:7]=0x0 DMAR[6:6]=0x0 HDSEL[3:3]=0x0 EIE[0:0]=0x0 |
| ISR  | 0x4000481c | 0x000000c0 | REACK[22:22]=0x0 TEACK[21:21]=0x0 WUF[20:20]=0x0 RWU[19:19]=0x0 SBKF[18:18]=0x0 CMF[17:17]=0x0       |
|      |            |            | BUSY[16:16]=0x0 CTS[10:10]=0x0 CTSIF[9:9]=0x0 TXE[7:7]=0x1 TC[6:6]=0x1                               |
|      |            |            | RXNE[5:5]=0x0 IDLE[4:4]=0x0 ORE[3:3]=0x0 NF[2:2]=0x0 FE[1:1]=0x0 PE[0:0]=0x0                         |
+------+------------+------------+------------------------------------------------------------------------------------------------------+
```